### PR TITLE
Trivial fix for encoding issue

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,13 @@
+nagios-plugins-ceph (1.5.2) unstable; urgency=medium
+
+  * Changed the version number to fix "dpkg-source: error:
+    can't build with source format '3.0 (native)': native package version may
+    not have a revision"
+  * Changed "python-support" dependency to "python", since the former is
+    absent from stretch.
+
+ -- Ash <ash.github@comtek.co.uk> Tue, 19 Sep 2017 21:09:00 +0000
+
 nagios-plugins-ceph (1.5.1-1) unstable; urgency=medium
 
   * Added whitelist regexp filter for good/unhandled ceph health warnings

--- a/debian/changelog
+++ b/debian/changelog
@@ -6,7 +6,7 @@ nagios-plugins-ceph (1.5.2) unstable; urgency=medium
   * Changed "python-support" dependency to "python", since the former is
     absent from stretch.
 
- -- Ash <ash.github@comtek.co.uk> Tue, 19 Sep 2017 21:09:00 +0000
+ -- Ash <ash.github@comtek.co.uk>  Tue, 19 Sep 2017 21:09:00 +0000
 
 nagios-plugins-ceph (1.5.1-1) unstable; urgency=medium
 

--- a/debian/control
+++ b/debian/control
@@ -4,10 +4,10 @@ Uploaders: Sebastian Nickel <sebastian.nickel@nine.ch>, Roman Plessl <roman.ples
 Section: misc
 Priority: optional
 Standards-Version: 3.9.5
-Build-Depends: debhelper (>= 8), python
+Build-Depends: debhelper (>= 8), python-all
 
 Package: nagios-plugins-ceph
 Architecture: all
-Depends: ${python:Depends}, ${misc:Depends}
+Depends: python-all
 Description: Nagios plugins for Ceph
  This package provides a set of plugins to monitor a ceph cluster.

--- a/debian/control
+++ b/debian/control
@@ -4,7 +4,7 @@ Uploaders: Sebastian Nickel <sebastian.nickel@nine.ch>, Roman Plessl <roman.ples
 Section: misc
 Priority: optional
 Standards-Version: 3.9.5
-Build-Depends: debhelper (>= 8), python-support
+Build-Depends: debhelper (>= 8), python
 
 Package: nagios-plugins-ceph
 Architecture: all

--- a/src/check_ceph_rgw
+++ b/src/check_ceph_rgw
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+# coding=utf-8
 #
 #  Copyright (c) 2014 Catalyst IT http://www.catalyst.net.nz
 #  Copyright (c) 2015 SWITCH http://www.switch.ch


### PR DESCRIPTION
SyntaxError: Non-ASCII character '\xc3' in file ./check_ceph_rgw on line 19, but no encoding declared; see http://python.org/dev/peps/pep-0263/ for details

Fixed by adding "coding=utf-8" line.