### PR TITLE
Set python unicode encoding for check scripts

### DIFF
--- a/src/check_ceph_df
+++ b/src/check_ceph_df
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+# -*- coding: utf-8 -*-
 #
 #  Copyright (c) 2013 SWITCH http://www.switch.ch
 #
@@ -128,10 +129,10 @@ def main():
                         return STATUS_ERROR
                     if pool_usage_percent > args.warn:
                         print 'WARNING: Pool \'%s\' usage of %s%% is above %s%% (%s used)' % (args.pool, pool_usage_percent, args.warn, pool_used)
-                        return STATUS_WARNING    
-                    else: 
+                        return STATUS_WARNING
+                    else:
                         print 'Pool \'%s\' usage %s%%' % (args.pool, pool_usage_percent)
-                        return STATUS_OK  
+                        return STATUS_OK
         else:
             # print 'DEBUG:', globalvals
             # finally 4th element contains percentual value
@@ -161,7 +162,7 @@ def main():
                 print 'RAW usage %s%% | Usage=%s%%;%s;%s;;' % (global_usage_percent, global_usage_percent, args.warn, args.critical)
                 return STATUS_OK
 
-        #for 
+        #for
     elif err:
         # read only first line of error
         one_line = err.split('\n')[0]
@@ -176,4 +177,3 @@ def main():
 
 if __name__ == "__main__":
     sys.exit(main())
-

--- a/src/check_ceph_health
+++ b/src/check_ceph_health
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+# -*- coding: utf-8 -*-
 #
 #  Copyright (c) 2013-2016 SWITCH http://www.switch.ch
 #

--- a/src/check_ceph_mds
+++ b/src/check_ceph_mds
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+# -*- coding: utf-8 -*-
 #
 #  Copyright (c) 2013 Catalyst IT http://www.catalyst.net.nz
 #  Copyright (c) 2015 SWITCH http://www.switch.ch
@@ -90,7 +91,7 @@ def main():
     if p.returncode != 0 or not output:
         print "MDS ERROR: %s" % err
         return STATUS_ERROR
-  
+
     # load json output and parse
     mds_stat = None
     try:
@@ -108,7 +109,7 @@ def check_target_mds(mds_stat, fs_name, name):
         if mds.get_name() == name:
             print "MDS OK: %s" % (mds)
             return STATUS_OK
-        
+
     # find mds from active list
     active_mdss = _get_active_mds(mds_stat, fs_name)
     for mds in active_mdss:
@@ -178,4 +179,3 @@ class MDS(object):
 # main
 if __name__ == "__main__":
   sys.exit(main())
-

--- a/src/check_ceph_mon
+++ b/src/check_ceph_mon
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+# -*- coding: utf-8 -*-
 #
 #  Copyright (c) 2013 Catalyst IT http://www.catalyst.net.nz
 #  Copyright (c) 2015 SWITCH http://www.switch.ch
@@ -159,4 +160,3 @@ def main():
 # main
 if __name__ == "__main__":
   sys.exit(main())
-

--- a/src/check_ceph_osd
+++ b/src/check_ceph_osd
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+# -*- coding: utf-8 -*-
 #
 #  Copyright (c) 2013 Catalyst IT http://www.catalyst.net.nz
 #
@@ -148,4 +149,3 @@ def main():
 
 if __name__ == "__main__":
     sys.exit(main())
-

--- a/src/check_ceph_rgw
+++ b/src/check_ceph_rgw
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+# -*- coding: utf-8 -*-
 #
 #  Copyright (c) 2014 Catalyst IT http://www.catalyst.net.nz
 #  Copyright (c) 2015 SWITCH http://www.switch.ch
@@ -114,4 +115,3 @@ def main():
 
 if __name__ == "__main__":
   sys.exit(main())
-


### PR DESCRIPTION
This PR fix issue with `check_ceph_rgw`:

```
$ python --version
Python 2.7.5
$ python check_ceph_rgw 
  File "check_ceph_rgw", line 19
SyntaxError: Non-ASCII character '\xc3' in file check_ceph_rgw on line 19, but no encoding declared; see http://www.python.org/peps/pep-0263.html for details
```

I also set encoding for all scripts.