### PR TITLE
Added check_ceph_rgw_api plugin.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -5,3 +5,4 @@ Walter Huf <hufman+github@gmail.com>
 Sebiastian Nickel <sebastian.nickel@nine.ch>
 Roman Plessl <roman.plessl@nine.ch>
 Vincent <minsheng.l@inwinstack.com>
+Konstantin Shalygin <k0ste@k0ste.ru>

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,27 +1,29 @@
 Nagios plugins for Ceph
 -----------------------
+Version 1.5.3:
+* `check_ceph_rgw_api` plugin added.
+
 Version 1.5.0:
-* check_ceph_df plugin added.
+* `check_ceph_df` plugin added.
 
 Version 1.4.0:
-* Refactored check_ceph_mon plugin (v1.1.0), parses ceph quorum_status output.
+* Refactored `check_ceph_mon plugin` (v1.1.0), parses ceph quorum_status output.
 
 Version 1.3.1:
-* check_ceph_rgw with detailed bucket stats as perf data (--detail).
+* `check_ceph_rgw` with detailed bucket stats as perf data (--detail).
 
 Version 1.3.0:
-* check_ceph_rgw with bucket stats as perf data.
+* `check_ceph_rgw` with bucket stats as perf data.
 
 Version 1.2.0:
-* check_ceph_rgw plugin added.
+* `check_ceph_rgw` plugin added.
 
 Version 1.1.0:
-* check_ceph_mon plugin added.
-* check_ceph_osd plugin added.
+* `check_ceph_mon` plugin added.
+* `check_ceph_osd` plugin added.
 
 Version 1.0.1:
 * HEALTH_OK doesn't always have additional information.
 
 Version 1.0:
 * Initial 'ceph health' nagios plugin.
-

--- a/README.md
+++ b/README.md
@@ -155,6 +155,74 @@ Possible result includes OK (up), WARN (down or missing).
     nagios$ ./check_ceph_rgw --detail --byte
     RGW OK: 4 buckets, 102276 KB total | /=104730624B bucket-test1=151552B bucket-test0=12288B bucket-test2=104566784B bucket-test=0B
 
+## check_ceph_rgw_api
+
+The `check_ceph_rgw_api` nagios plugin monitors a ceph rados gateway, reporting
+its status and buckets usage.
+
+##### Difference with `check_ceph_rgw`:
+
+`check_ceph_rgw` is designed for connect to cluster, `check_ceph_rgw_api` is
+connected to radosgw directly via
+[admin api](http://docs.ceph.com/docs/master/radosgw/adminops/). You can
+check each instance of radosgw or only one endpoint via proxy/balancer
+(or both).
+
+#### Possible results
+- OK - bucket info recieved from radosgw;
+- WARNING - connected, but wrong admin entry or usage caps;
+- UNKNOWN - can't connect to proxy/balancer or radosgw directly;
+
+#### Requirements
+
+1. Install [requests-aws](//github.com/tax/python-requests-aws) python library:
+```
+pip install requests-aws
+```
+
+2. Configure admin entry point (default is 'admin'):
+```
+rgw admin entry = "admin"
+```
+
+3. Enable admin API (default is enabled):
+```
+rgw enable apis = "s3, admin"
+```
+
+4. Add capability `buckets=read` for your user who performed checks, see
+[Admin Guide](http://docs.ceph.com/docs/master/radosgw/admin/#add-remove-admin-capabilities)
+for more details.
+
+### Usage
+    usage: check_ceph_rgw_api [-h] -H HOST [-e ADMIN_ENTRY] -a ACCESS_KEY -s
+                              SECRET_KEY [-d] [-B] [-v]
+
+    'radosgw api bucket stats' nagios plugin.
+
+    optional arguments:
+      -h, --help            show this help message and exit
+      -H HOST, --host HOST  Server URL for the radosgw api (example:
+                            http://objects.dreamhost.com/)
+      -e ADMIN_ENTRY, --admin_entry ADMIN_ENTRY
+                            The entry point for an admin request URL [default is
+                            'admin']
+      -a ACCESS_KEY, --access_key ACCESS_KEY
+                            S3 access key
+      -s SECRET_KEY, --secret_key SECRET_KEY
+                            S3 secret key
+      -d, --detail          output perf data for all buckets
+      -b, --byte            output perf data in Byte instead of KB
+      -v, --version         show version and exit
+
+### Example
+
+    nagios$ ./check_ceph_rgw_api -H https://objects.dreamhost.com/ -a JXUABTZZYHAFLCMF9VYV -s jjP8RDD0R156atS6ACSy2vNdJLdEPM0TJQ5jD1pw
+    RGW OK: 1 buckets, 7696 KB total | /=7696KB
+
+    nagios$ ./check_ceph_rgw_api -H objects.dreamhost.com -a JXUABTZZYHAFLCMF9VYV -s jjP8RDD0R156atS6ACSy2vNdJLdEPM0TJQ5jD1pw --detail --byte
+    RGW OK: 1 buckets, 7696 KB total | /=7880704B k0ste=7880704B
+
 ## check_ceph_df
 
 The `check_ceph_df` nagios plugin monitors a ceph cluster, reporting its percentual RAW capacity usage, or specific pool usage.

--- a/config/ceph.cfg
+++ b/config/ceph.cfg
@@ -28,6 +28,10 @@ define command{
         command_line    /usr/lib/nagios/plugins/check_ceph_rgw
 }
 define command{
+        command_name    check_ceph_rgw_api
+        command_line    /usr/lib/nagios/plugins/check_ceph_rgw_api -h '$HOSTADDRESS$' -a '$ARG1$' -s '$ARG2$'
+}
+define command{
         command_name    check_ceph_df
         command_line    /usr/lib/nagios/plugins/check_ceph_df -m '$ARG1$' -i '$ARG2$' -k '$ARG3$' -W '$ARG4$' -C '$ARG5$' $ARG6$
 }

--- a/src/check_ceph_rgw_api
+++ b/src/check_ceph_rgw_api
@@ -1,0 +1,107 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+#  Copyright (c) 2014 Catalyst IT http://www.catalyst.net.nz
+#  Copyright (c) 2015 SWITCH http://www.switch.ch
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import requests
+import json
+import argparse
+import sys
+from awsauth import S3Auth
+
+__version__ = '1.5.3'
+
+# nagios exit code
+STATUS_OK = 0
+STATUS_WARNING = 1
+STATUS_CRITICAL = 2
+STATUS_UNKNOWN = 3
+
+def main():
+
+  # parse args
+  parser = argparse.ArgumentParser(description="'radosgw api bucket stats' nagios plugin.")
+  parser.add_argument('-H', '--host', help="Server URL for the radosgw api (example: http://objects.dreamhost.com/)", required=True)
+  parser.add_argument('-e', '--admin_entry', help="The entry point for an admin request URL [default is '%(default)s']", default="admin")
+  parser.add_argument('-a', '--access_key', help="S3 access key", required=True)
+  parser.add_argument('-s', '--secret_key', help="S3 secret key", required=True)
+  parser.add_argument('-d', '--detail', help="output perf data for all buckets", action="store_true")
+  parser.add_argument('-b', '--byte', help="output perf data in Byte instead of KB", action="store_true")
+  parser.add_argument('-v', '--version', help='show version and exit', action="store_true")
+  args = parser.parse_args()
+
+  if args.version:
+      print("version {0}".format(__version__))
+      return STATUS_OK
+
+  # helpers for default schema
+  if not args.host.startswith("http"):
+      args.host = "http://{0}".format(args.host)
+  # and for request_uri
+  if not args.host.endswith("/"):
+      args.host = "{0}/".format(args.host)
+
+  url = "{0}{1}/bucket?format=json&stats=True".format(args.host,
+                                                      args.admin_entry)
+
+  try:
+      response = requests.get(url, auth=S3Auth(args.access_key, args.secret_key,
+                                               args.host))
+
+      if response.status_code == requests.codes.ok:
+          bucket_stats = response.json()
+      else:
+          # no usage caps or wrong admin entry
+          print("RGW ERROR [{0}]: {1}".format(response.status_code,
+                                              response.content.decode('utf-8')))
+          return STATUS_WARNING
+
+# DNS, connection errors, etc
+  except requests.exceptions.RequestException as e:
+      print("RGW ERROR: {0}".format(e))
+      return STATUS_UNKNOWN
+
+  #print(bucket_stats)
+  buckets = []
+  for i in bucket_stats:
+    if type(i) is dict:
+      bucket_name = i['bucket']
+      usage_dict = i['usage']
+      if not usage_dict:
+        bucket_usage_kb = 0
+      else:
+        bucket_usage_kb = usage_dict['rgw.main']['size_kb_actual']
+      buckets.append((bucket_name, bucket_usage_kb))
+  buckets_total_kb = sum([b[1] for b in buckets])
+
+  status = "RGW OK: {0} buckets, {1} KB total | /={2}{3} "
+
+  if args.byte:
+    status = status.format(len(buckets), buckets_total_kb, buckets_total_kb*1024, "B")
+  else:
+    status = status.format(len(buckets), buckets_total_kb, buckets_total_kb, "KB")
+  #print(buckets)
+  if buckets and args.detail:
+    if args.byte:
+      status = status + " ".join(["{}={}B".format(b[0], b[1]*1024) for b in buckets])
+    else:
+      status = status + " ".join(["{}={}KB".format(b[0], b[1]) for b in buckets])
+
+  print(status)
+  return STATUS_OK
+
+if __name__ == "__main__":
+  sys.exit(main())


### PR DESCRIPTION
This is the same functionality as for present `radosgw-admin` wrapper, but checks is performed via [admin api](http://docs.ceph.com/docs/master/radosgw/adminops/).

Motivation:
1. Ability to check every rgw instance.
2. Performance.
3. Independence from ceph packages.

Tests with Luminous 12.2.4

```
nagios$ time ./check_ceph_rgw
RGW OK: 1 buckets, 7696 KB total | /=7696KB 

real    0m0.724s
user    0m0.055s
sys     0m0.015s
```
```
nagios$ time ./check_ceph_rgw_api -H http://10.10.10.1/ -a <snip> -s <snap>
RGW OK: 1 buckets, 7696 KB total | /=7696KB 

real    0m0.087s
user    0m0.053s
sys     0m0.016s
```

In my environment admin api works much faster.

Plugin tested with python 2.7 and 3.6. With http and https.