### PR TITLE
Fixed issue when bucket exists, but 'usage' is empty due RGW bug

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,9 @@
 Nagios plugins for Ceph
 -----------------------
+Version 1.5.6:
+* `check_ceph_rgw`, `check_ceph_rgw_api`: handled possible situations when
+   bucket exists, but is empty (rgw bugs).
+
 Version 1.5.5:
 * `check_ceph_mgr` plugin added.
 

--- a/src/check_ceph_mds
+++ b/src/check_ceph_mds
@@ -15,7 +15,7 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-#
+
 
 import argparse
 import socket

--- a/src/check_ceph_rgw
+++ b/src/check_ceph_rgw
@@ -15,9 +15,7 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-#
-# changes:
-# 2017-07-27: add client name option, André Klausnitzer <info@b1-systems.de>
+
 
 import argparse
 import os
@@ -26,7 +24,7 @@ import subprocess
 import sys
 import json
 
-__version__ = '1.5.0'
+__version__ = '1.5.1'
 
 # default ceph values
 RGW_COMMAND = '/usr/bin/radosgw-admin'
@@ -88,17 +86,19 @@ def main():
 
   bucket_stats = json.loads(output)
   #print bucket_stats
+
   buckets = []
   for i in bucket_stats:
     if type(i) is dict:
       bucket_name = i['bucket']
       usage_dict = i['usage']
-      if not usage_dict:
-        bucket_usage_kb = 0
-      else:
+      if usage_dict and 'rgw.main' in usage_dict:
         bucket_usage_kb = usage_dict['rgw.main']['size_kb_actual']
+      else:
+        bucket_usage_kb = 0
       buckets.append((bucket_name, bucket_usage_kb))
-  buckets_total_kb =  sum([b[1] for b in buckets])
+  buckets_total_kb = sum([b[1] for b in buckets])
+
   if args.byte:
     status = "RGW OK: {} buckets, {} KB total | /={}B ".format(len(buckets),buckets_total_kb,buckets_total_kb*1024)
   else:

--- a/src/check_ceph_rgw_api
+++ b/src/check_ceph_rgw_api
@@ -16,6 +16,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
+
 import requests
 import warnings
 import json
@@ -23,7 +24,7 @@ import argparse
 import sys
 from awsauth import S3Auth
 
-__version__ = '1.7.1'
+__version__ = '1.7.2'
 
 # nagios exit code
 STATUS_OK = 0
@@ -88,10 +89,10 @@ def main():
     if type(i) is dict:
       bucket_name = i['bucket']
       usage_dict = i['usage']
-      if not usage_dict:
-        bucket_usage_kb = 0
-      else:
+      if usage_dict and 'rgw.main' in usage_dict:
         bucket_usage_kb = usage_dict['rgw.main']['size_kb_actual']
+      else:
+        bucket_usage_kb = 0
       buckets.append((bucket_name, bucket_usage_kb))
   buckets_total_kb = sum([b[1] for b in buckets])
 


### PR DESCRIPTION
```python
Traceback (most recent call last):
  File "./check_ceph_rgw_api", line 115, in <module>
    sys.exit(main())
  File "./check_ceph_rgw_api", line 94, in main
    bucket_usage_kb = usage_dict['rgw.main']['size_kb_actual']
KeyError: 'rgw.main'
```

This possible with old RGW's due multipart bugs, for example
this bucket impossible to delete, because multiparts objects
is not exits. So better just skip this bucket.

```json
{
    "object": "_multipart_obj_tag.txt.2~KFWA-rRXHsFLc45G3-rDFimIM4yD1aU.meta"
}
{
    "existing_header": {
        "usage": {
            "rgw.multimeta": {
                "size": 0,
                "size_actual": 0,
                "size_utilized": 0,
                "size_kb": 0,
                "size_kb_actual": 0,
                "size_kb_utilized": 0,
                "num_objects": 1
            }
        }
    },
    "calculated_header": {
        "usage": {
            "rgw.multimeta": {
                "size": 0,
                "size_actual": 0,
                "size_utilized": 0,
                "size_kb": 0,
                "size_kb_actual": 0,
                "size_kb_utilized": 0,
                "num_objects": 1
            }
        }
    }
}
```