### PR TITLE
Convert output to utf-8

### DIFF
--- a/src/check_ceph_df
+++ b/src/check_ceph_df
@@ -101,6 +101,7 @@ def main():
     # print "DEBUG: output:", output
     # print "DEBUG: err:", err
     if output:
+        output = output.decode('utf-8')
         # parse output
         # if detail switch was not set only show global values and compare to warning and critical
         # otherwise show space for pools too

--- a/src/check_ceph_df
+++ b/src/check_ceph_df
@@ -22,7 +22,7 @@ import os
 import subprocess
 import sys
 
-__version__ = '1.7.0'
+__version__ = '1.7.1'
 
 # default ceph values
 CEPH_COMMAND = '/usr/bin/ceph'


### PR DESCRIPTION
Avoid `TypeError: a bytes-like object is required, not 'str'` - addresses #70 