### PR TITLE
refs #74 - use proper client id argument

### DIFF
--- a/src/check_ceph_rgw
+++ b/src/check_ceph_rgw
@@ -69,7 +69,7 @@ def main():
     rgw_cmd.append('-c')
     rgw_cmd.append(args.conf)
   if args.id:
-    rgw_cmd.append('-i')
+    rgw_cmd.append('--id')
     rgw_cmd.append(args.id)
   if args.name:
     rgw_cmd.append('-n')


### PR DESCRIPTION
 As radosgw-admin is a CEPH_ENTITY_TYPE_CLIENT, --id needs to be appended instead of -i, when constructing the rgw_cmd.