### PR TITLE
Use --id instead of -i when invoking radosgw-admin

### DIFF
--- a/src/check_ceph_rgw
+++ b/src/check_ceph_rgw
@@ -69,7 +69,7 @@ def main():
     rgw_cmd.append('-c')
     rgw_cmd.append(args.conf)
   if args.id:
-    rgw_cmd.append('-i')
+    rgw_cmd.append('--id')
     rgw_cmd.append(args.id)
   if args.name:
     rgw_cmd.append('-n')


### PR DESCRIPTION
It appears that `radosgw-admin` has no -`i` flag, instead it provides `--id`.